### PR TITLE
Feature/epc ss

### DIFF
--- a/include/Kanoop/gui/abstractitemmodel.h
+++ b/include/Kanoop/gui/abstractitemmodel.h
@@ -98,7 +98,7 @@ protected:
 
     void emitRowChanged(const QModelIndex &rowIndex);
 
-    static QString toString(const QModelIndex& value);
+    static QString toString(const QModelIndex& index);
 
 private:
     void commonInit();

--- a/include/Kanoop/gui/abstractitemmodel.h
+++ b/include/Kanoop/gui/abstractitemmodel.h
@@ -42,7 +42,9 @@ public:
     QModelIndex firstIndexOfEntity(int type, const QVariant &data, int role = Qt::DisplayRole) const;
     QModelIndex firstIndexOfEntityUuid(const QUuid& uuid) const;
     QModelIndex firstIndexOfChildEntityType(const QModelIndex& parent, int type) const;
+    QModelIndex firstIndexOfChildEntityUuid(const QModelIndex& parent, const QUuid& uuid) const;
     QModelIndex firstMatch(const QModelIndex& startSearchIndex, int role, const QVariant& value, Qt::MatchFlags flags = Qt::MatchFlags(Qt::MatchStartsWith|Qt::MatchWrap)) const;
+    QModelIndexList childIndexes(const QModelIndex& parent, int type) const;
 
     TableHeader::List columnHeaders() const;
     TableHeader columnHeader(int column) const { return _columnHeaders.value(column); }
@@ -51,7 +53,7 @@ public:
 
     QModelIndexList getPersistentIndexes() const;
 
-    void refresh(const QModelIndex& topLeft, const QModelIndex& bottomRight);
+    virtual void refresh(const QModelIndex& topLeft, const QModelIndex& bottomRight);
 
     // QAbstractItemModel interface
     virtual QModelIndex index(int row, int column, const QModelIndex &parent = QModelIndex()) const override;
@@ -68,6 +70,7 @@ public:
 protected:
     // Retrieve root items
     AbstractModelItem::List rootItems() const { return _rootItems; }
+    AbstractModelItem::List& rootItemsRef() { return _rootItems; }
     const AbstractModelItem::List rootItemsConst() const { return _rootItems; }
     int rootItemCount() const { return _rootItems.count(); }
 
@@ -118,6 +121,7 @@ signals:
     void itemUpdated(const EntityMetadata& metadata);
 
 public slots:
+    virtual void clear();
     virtual void addItem(const EntityMetadata& metadata) { Q_UNUSED(metadata) }
     virtual void deleteItem(const EntityMetadata& metadata) { Q_UNUSED(metadata) }
     virtual void updateItem(const EntityMetadata& metadata) { Q_UNUSED(metadata) }

--- a/include/Kanoop/gui/abstracttreemodel.h
+++ b/include/Kanoop/gui/abstracttreemodel.h
@@ -23,8 +23,6 @@ public:
 
 protected:
     // AbstractItemModel interface
-    virtual int columnCount(const QModelIndex &parent) const override;
-    virtual QVariant data(const QModelIndex &index, int role) const override;
     virtual void columnChangedAtRowIndex(const QModelIndex& rowIndex, int columnHeader);
 };
 

--- a/include/Kanoop/gui/tableviewbase.h
+++ b/include/Kanoop/gui/tableviewbase.h
@@ -47,6 +47,9 @@ public:
 
     void setColumnDelegate(int type, QStyledItemDelegate* delegate);
 
+public slots:
+    void clear();
+
 private:
     AbstractItemModel* _sourceModel;
     QSortFilterProxyModel* _proxyModel;
@@ -55,6 +58,7 @@ private:
     QAction* _actionColSettings = nullptr;
     QAction* _actionHideCol = nullptr;
     QAction* _actionAutoResizeCols = nullptr;
+    QAction* _actionResetCols = nullptr;
 
 signals:
     void horizontalHeaderChanged();
@@ -79,6 +83,7 @@ private slots:
     void onColumnSettingsClicked();
     void onHideColumnClicked();
     void onAutoResizeColumnsClicked();
+    void onResetColumnsClicked();
 };
 
 #endif // TABLEVIEWBASE_H

--- a/include/Kanoop/gui/treeviewbase.h
+++ b/include/Kanoop/gui/treeviewbase.h
@@ -32,6 +32,7 @@ public:
     EntityMetadata metadataAtPos(const QPoint& pos) const;
 
     QModelIndex firstIndexOfEntityUuid(const QUuid& uuid) const;
+    QModelIndexList indexesOfUuid(const QUuid& uuid) const;
     void setCurrentUuid(const QUuid& uuid);
 
     QByteArray saveState() const;
@@ -43,11 +44,15 @@ public:
     AbstractItemModel* sourceModel() const { return _sourceModel; }
     QSortFilterProxyModel* proxyModel() const { return _proxyModel; }
 
-    void refreshVisible();
-
     void collapseRecursively(const QModelIndex& index, int depth = -1);
 
     void setColumnDelegate(int type, QStyledItemDelegate* delegate);
+
+public slots:
+    void refreshVisibleIndexes(const QModelIndexList& indexes);
+    void refreshIndex(const QModelIndex& sourceIndex);
+    void refreshVisible();
+    void clear();
 
 protected:
     EntityMetadata findCurrentParent(int entityMetadataType) const;
@@ -62,6 +67,7 @@ private:
 signals:
     void itemProgramaticallySelected(const QModelIndex& index);
     void headerChanged();
+    void currentSelectionChanged();
 
 private slots:
     virtual void onHorizontalHeaderResized(int /*logicalIndex*/, int /*oldSize*/, int /*newSize*/);

--- a/include/Kanoop/gui/treeviewbase.h
+++ b/include/Kanoop/gui/treeviewbase.h
@@ -45,6 +45,8 @@ public:
 
     void refreshVisible();
 
+    void collapseRecursively(const QModelIndex& index, int depth = -1);
+
     void setColumnDelegate(int type, QStyledItemDelegate* delegate);
 
 protected:

--- a/include/Kanoop/gui/utility/stylesheet.h
+++ b/include/Kanoop/gui/utility/stylesheet.h
@@ -23,12 +23,18 @@ public:
     void setProperty(StyleSheetProperty property, const QString& value);
     void setProperty(StyleSheetProperty property, const QColor& value);
     void setPropertyPixels(StyleSheetProperty property, int value);
+
+    void setPseudoState(StyleSheetPseudoState value) { _pseudoState = value; }
+    void setSubControl(const QString& value) { _subControl = value; }
+
     QString toString() const;
 
 
     QString _typeName;
 
     QMap<StyleSheetProperty, QString> _properties;
+    StyleSheetPseudoState _pseudoState = PS_Invalid;
+    QString _subControl;
 };
 
 #endif // STYLESHEET_H

--- a/include/Kanoop/gui/utility/stylesheettypes.h
+++ b/include/Kanoop/gui/utility/stylesheettypes.h
@@ -105,6 +105,8 @@ enum StyleSheetProperty {
 };
 
 enum StyleSheetPseudoState {
+    PS_Invalid = 0,
+
     PS_Active,                  // This state is set when the widget resides in an active window.
     PS_AdjoinsItem,             // This state is set when the ::branch of a QTreeView is adjacent to an item.
     PS_Alternate,               // This state is set for every alternate row whe painting the row of a QAbstractItemView when QAbstractItemView::alternatingRowColors() is set to true.
@@ -268,50 +270,50 @@ private:
     public:
         PseudoStateToStringMap()
         {
-            insert(PS_Active,               ":active");
-            insert(PS_AdjoinsItem,          ":adjoins-item");
-            insert(PS_Alternate,            ":alternate");
-            insert(PS_Bottom,               ":bottom");
-            insert(PS_Checked,              ":checked");
-            insert(PS_Closable,             ":closable");
-            insert(PS_Closed,               ":closed");
-            insert(PS_Default,              ":default");
-            insert(PS_Disabled,             ":disabled");
-            insert(PS_Editable,             ":editable");
-            insert(PS_EditFocus,            ":edit-focus");
-            insert(PS_Enabled,              ":enabled");
-            insert(PS_Exclusive,            ":exclusive");
-            insert(PS_First,                ":first");
-            insert(PS_Flat,                 ":flat");
-            insert(PS_Floatable,            ":floatable");
-            insert(PS_Focus,                ":focus");
-            insert(PS_HasChildren,          ":has-children");
-            insert(PS_HasSiblings,          ":has-siblings");
-            insert(PS_Horizontal,           ":horizontal");
-            insert(PS_Hover,                ":hover");
-            insert(PS_Indeterminate,        ":indeterminate");
-            insert(PS_Last,                 ":last");
-            insert(PS_Left,                 ":left");
-            insert(PS_Maximized,            ":maximized");
-            insert(PS_Middle,               ":middle");
-            insert(PS_Minimized,            ":minimized");
-            insert(PS_Movable,              ":movable");
-            insert(PS_NoFrame,              ":no-frame");
-            insert(PS_NonExclusive,         ":non-exclusive");
-            insert(PS_Off,                  ":off");
-            insert(PS_On,                   ":on");
-            insert(PS_OnlyOne,              ":only-one");
-            insert(PS_Open,                 ":open");
-            insert(PS_NextSelected,         ":next-selected");
-            insert(PS_Pressed,              ":pressed");
-            insert(PS_PreviousSelected,     ":previous-selected");
-            insert(PS_ReadOnly,             ":read-only");
-            insert(PS_Right,                ":right");
-            insert(PS_Selected,             ":selected");
-            insert(PS_Top,                  ":top");
-            insert(PS_Unchecked,            ":unchecked");
-            insert(PS_Vertical,             ":vertical");
-            insert(PS_Window,               ":window");
+            insert(PS_Active,               "active");
+            insert(PS_AdjoinsItem,          "adjoins-item");
+            insert(PS_Alternate,            "alternate");
+            insert(PS_Bottom,               "bottom");
+            insert(PS_Checked,              "checked");
+            insert(PS_Closable,             "closable");
+            insert(PS_Closed,               "closed");
+            insert(PS_Default,              "default");
+            insert(PS_Disabled,             "disabled");
+            insert(PS_Editable,             "editable");
+            insert(PS_EditFocus,            "edit-focus");
+            insert(PS_Enabled,              "enabled");
+            insert(PS_Exclusive,            "exclusive");
+            insert(PS_First,                "first");
+            insert(PS_Flat,                 "flat");
+            insert(PS_Floatable,            "floatable");
+            insert(PS_Focus,                "focus");
+            insert(PS_HasChildren,          "has-children");
+            insert(PS_HasSiblings,          "has-siblings");
+            insert(PS_Horizontal,           "horizontal");
+            insert(PS_Hover,                "hover");
+            insert(PS_Indeterminate,        "indeterminate");
+            insert(PS_Last,                 "last");
+            insert(PS_Left,                 "left");
+            insert(PS_Maximized,            "maximized");
+            insert(PS_Middle,               "middle");
+            insert(PS_Minimized,            "minimized");
+            insert(PS_Movable,              "movable");
+            insert(PS_NoFrame,              "no-frame");
+            insert(PS_NonExclusive,         "non-exclusive");
+            insert(PS_Off,                  "off");
+            insert(PS_On,                   "on");
+            insert(PS_OnlyOne,              "only-one");
+            insert(PS_Open,                 "open");
+            insert(PS_NextSelected,         "next-selected");
+            insert(PS_Pressed,              "pressed");
+            insert(PS_PreviousSelected,     "previous-selected");
+            insert(PS_ReadOnly,             "read-only");
+            insert(PS_Right,                "right");
+            insert(PS_Selected,             "selected");
+            insert(PS_Top,                  "top");
+            insert(PS_Unchecked,            "unchecked");
+            insert(PS_Vertical,             "vertical");
+            insert(PS_Window,               "window");
         }
     };
 

--- a/src/gui/abstractitemmodel.cpp
+++ b/src/gui/abstractitemmodel.cpp
@@ -98,7 +98,7 @@ int AbstractItemModel::columnCount(const QModelIndex &parent) const
 {
     logText(LVL_DEBUG, LVL3(), QString("%1  parent: [%2]").arg(__FUNCTION__).arg(toString(parent)));
 
-    return _columnHeaders.count() ? _columnHeaders.count() : 1;
+    return qMax(1, columnHeadersIntMap().count());
 }
 
 QVariant AbstractItemModel::data(const QModelIndex &index, int role) const
@@ -116,8 +116,18 @@ QVariant AbstractItemModel::data(const QModelIndex &index, int role) const
                 result = item->data(index, role);
                 break;
             case Qt::DecorationRole:
-                result = item->icon();
+                if(index.column() == 0) {
+                    result = item->icon();
+                }
                 break;
+            case Qt::ForegroundRole:
+            {
+                TableHeader header = columnHeader(index.column());
+                if(header.columnTextColor().isValid()) {
+                    result = header.columnTextColor();
+                }
+                break;
+            }
             case KANOOP::EntityTypeRole:
                 result = item->entityType();
                 break;
@@ -384,13 +394,12 @@ void AbstractItemModel::emitRowChanged(const QModelIndex &rowIndex)
     emit dataChanged(firstColIndex, lastColIndex);
 }
 
-QString AbstractItemModel::toString(const QModelIndex &value)
+QString AbstractItemModel::toString(const QModelIndex &index)
 {
-    return QString("row: %1  col: %2  ptr: 0x%3   [%4]")
-            .arg(value.row())
-            .arg(value.column())
-            .arg((qint64)value.constInternalPointer(), 0, 16)
-            .arg(value.data(Qt::DisplayRole).toString());
+    return QString("row: %1  col: %2  ptr: 0x%3")
+            .arg(index.row())
+            .arg(index.column())
+            .arg((quint64)index.constInternalPointer(), 0, 16);
 }
 
 

--- a/src/gui/abstracttreemodel.cpp
+++ b/src/gui/abstracttreemodel.cpp
@@ -26,7 +26,7 @@ void AbstractTreeModel::columnChangedAtRowIndex(const QModelIndex &rowIndex, int
 {
     int column = columnForHeader(columnHeader);
     if(column >= 0) {
-        QModelIndex columntIndex = index(rowIndex.row(), column, rowIndex.parent());
-        emit dataChanged(columntIndex, columntIndex);
+        QModelIndex columnIndex = index(rowIndex.row(), column, rowIndex.parent());
+        emit dataChanged(columnIndex, columnIndex);
     }
 }

--- a/src/gui/abstracttreemodel.cpp
+++ b/src/gui/abstracttreemodel.cpp
@@ -22,50 +22,6 @@ AbstractTreeModel::AbstractTreeModel(const QString &loggingCategory, QObject *pa
     AbstractItemModel::setObjectName(AbstractItemModel::metaObject()->className());
 }
 
-int AbstractTreeModel::columnCount(const QModelIndex &parent) const
-{
-    Q_UNUSED(parent)
-    int result = qMax(1, columnHeadersIntMap().count());
-    return result;
-}
-
-QVariant AbstractTreeModel::data(const QModelIndex &index, int role) const
-{
-    QVariant result;
-
-    if(index.isValid() && index.internalPointer() != nullptr) {
-        AbstractModelItem* item = static_cast<AbstractModelItem*>(index.internalPointer());
-        result = item->data(index, role);
-        if(result.isValid() == false) {
-            switch(role) {
-            case Qt::DisplayRole:
-                result = item->data(index, role);
-                break;
-            case Qt::DecorationRole:
-                if(index.column() == 0) {
-                    result = item->icon();
-                }
-                break;
-            case Qt::ForegroundRole:
-            {
-                TableHeader header = columnHeader(index.column());
-                if(header.columnTextColor().isValid()) {
-                    result = header.columnTextColor();
-                }
-                break;
-            }
-            case KANOOP::EntityTypeRole:
-                result = item->entityType();
-                break;
-            default:
-                break;
-            }
-        }
-    }
-
-    return result;
-}
-
 void AbstractTreeModel::columnChangedAtRowIndex(const QModelIndex &rowIndex, int columnHeader)
 {
     int column = columnForHeader(columnHeader);

--- a/src/gui/tableviewbase.cpp
+++ b/src/gui/tableviewbase.cpp
@@ -51,9 +51,11 @@ TableViewBase::TableViewBase(QWidget *parent) :
     _actionColSettings = new QAction("Column Settings", this);
     _actionHideCol = new QAction("Hide Column", this);
     _actionAutoResizeCols = new QAction("Auto-Resize Columns", this);
+    _actionResetCols = new QAction("Reset Columns", this);
     connect(_actionColSettings, &QAction::triggered, this, &TableViewBase::onColumnSettingsClicked);
     connect(_actionHideCol, &QAction::triggered, this, &TableViewBase::onHideColumnClicked);
     connect(_actionAutoResizeCols, &QAction::triggered, this, &TableViewBase::onAutoResizeColumnsClicked);
+    connect(_actionResetCols, &QAction::triggered, this, &TableViewBase::onResetColumnsClicked);
 
     // Custom context menu is the default
     setContextMenuPolicy(Qt::CustomContextMenu);
@@ -176,6 +178,13 @@ void TableViewBase::setColumnDelegate(int type, QStyledItemDelegate *delegate)
     }
 }
 
+void TableViewBase::clear()
+{
+    if(_sourceModel != nullptr) {
+        _sourceModel->clear();
+    }
+}
+
 void TableViewBase::onHorizontalHeaderResized(int, int, int)
 {
     if(GuiSettings::globalInstance() != nullptr && model() != nullptr) {
@@ -200,6 +209,8 @@ void TableViewBase::onHeaderContextMenuRequested()
     menu.addAction(_actionColSettings);
     menu.addAction(_actionHideCol);
     menu.addAction(_actionAutoResizeCols);
+    menu.addSeparator();
+    menu.addAction(_actionResetCols);
 
     menu.exec(QCursor::pos());
 }
@@ -240,5 +251,13 @@ void TableViewBase::onHideColumnClicked()
 void TableViewBase::onAutoResizeColumnsClicked()
 {
     horizontalHeader()->resizeSections(QHeaderView::ResizeToContents);
+}
+
+void TableViewBase::onResetColumnsClicked()
+{
+    for(int section = 0;section < horizontalHeader()->count();section++) {
+        horizontalHeader()->resizeSection(section, 120);
+    }
+    GuiSettings::globalInstance()->saveLastHeaderState(horizontalHeader(), sourceModel());
 }
 

--- a/src/gui/treeviewbase.cpp
+++ b/src/gui/treeviewbase.cpp
@@ -164,6 +164,18 @@ void TreeViewBase::refreshVisible()
     _sourceModel->refresh(topLeft, bottomRight);
 }
 
+void TreeViewBase::collapseRecursively(const QModelIndex& index, int depth)
+{
+    collapse(index);
+    int rows = model()->rowCount(index);
+    if(depth != 0) {
+        for(int row = 0;row < rows;row++) {
+            QModelIndex child = model()->index(row, 0, index);
+            collapseRecursively(child, depth < 0 ? -1 : depth - 1);
+        }
+    }
+}
+
 void TreeViewBase::setColumnDelegate(int type, QStyledItemDelegate *delegate)
 {
     QStyledItemDelegate* existing = _columnDelegates.value(type);

--- a/src/gui/utility/stylesheet.cpp
+++ b/src/gui/utility/stylesheet.cpp
@@ -8,6 +8,14 @@
 #include <QTableView>
 #include <QTextEdit>
 #include <QTreeView>
+#include <qcheckbox.h>
+#include <qcombobox.h>
+#include <qmenu.h>
+#include <qmenubar.h>
+#include <qplaintextedit.h>
+#include <qradiobutton.h>
+#include <qscrollbar.h>
+#include <qtoolbar.h>
 
 
 template<typename T>
@@ -64,3 +72,14 @@ template class StyleSheet<QTableView>;
 template class StyleSheet<QTextEdit>;
 template class StyleSheet<QLineEdit>;
 template class StyleSheet<QStatusBar>;
+template class StyleSheet<QToolBar>;
+template class StyleSheet<QMenu>;
+template class StyleSheet<QRadioButton>;
+template class StyleSheet<QPlainTextEdit>;
+template class StyleSheet<QMenuBar>;
+template class StyleSheet<QCheckBox>;
+template class StyleSheet<QComboBox>;
+template class StyleSheet<QTabWidget>;
+template class StyleSheet<QScrollBar>;
+template class StyleSheet<QTabBar>;
+

--- a/src/gui/utility/stylesheet.cpp
+++ b/src/gui/utility/stylesheet.cpp
@@ -2,6 +2,7 @@
 #include <QFrame>
 #include <QLabel>
 #include <QLineEdit>
+#include <QListView>
 #include <QPushButton>
 #include <QStatusBar>
 #include <QTableView>
@@ -32,7 +33,14 @@ QString StyleSheet<T>::toString() const
 {
     QString result;
     QTextStream output(&result);
-    output << QString("%1 {").arg(_typeName);
+    output << _typeName;
+    if(_subControl.isEmpty() == false) {
+        output << "::" << _subControl;
+    }
+    if(_pseudoState != PS_Invalid) {
+        output << ':' << StyleSheetStrings::getPseudoStateString(_pseudoState);
+    }
+    output << " {";
     QList<StyleSheetProperty> keys = _properties.keys();
     for(int i = 0; i < keys.count();i++) {
         StyleSheetProperty p = keys.at(i);
@@ -50,6 +58,7 @@ template class StyleSheet<QWidget>;
 template class StyleSheet<QFrame>;
 template class StyleSheet<QLabel>;
 template class StyleSheet<QPushButton>;
+template class StyleSheet<QListView>;
 template class StyleSheet<QTreeView>;
 template class StyleSheet<QTableView>;
 template class StyleSheet<QTextEdit>;

--- a/src/gui/utility/stylesheet.cpp
+++ b/src/gui/utility/stylesheet.cpp
@@ -8,14 +8,14 @@
 #include <QTableView>
 #include <QTextEdit>
 #include <QTreeView>
-#include <qcheckbox.h>
-#include <qcombobox.h>
-#include <qmenu.h>
-#include <qmenubar.h>
-#include <qplaintextedit.h>
-#include <qradiobutton.h>
-#include <qscrollbar.h>
-#include <qtoolbar.h>
+#include <QCheckBox>
+#include <QComboBox>
+#include <QMenu>
+#include <QMenuBar>
+#include <QPlainTextEdit>
+#include <QRadioButton>
+#include <QScrollBar>
+#include <QToolBar>
 
 
 template<typename T>

--- a/src/gui/utility/stylesheet.cpp
+++ b/src/gui/utility/stylesheet.cpp
@@ -4,7 +4,9 @@
 #include <QLineEdit>
 #include <QPushButton>
 #include <QStatusBar>
+#include <QTableView>
 #include <QTextEdit>
+#include <QTreeView>
 
 
 template<typename T>
@@ -48,6 +50,8 @@ template class StyleSheet<QWidget>;
 template class StyleSheet<QFrame>;
 template class StyleSheet<QLabel>;
 template class StyleSheet<QPushButton>;
+template class StyleSheet<QTreeView>;
+template class StyleSheet<QTableView>;
 template class StyleSheet<QTextEdit>;
 template class StyleSheet<QLineEdit>;
 template class StyleSheet<QStatusBar>;


### PR DESCRIPTION
## Jira Story
[SC-3381](https://epcpower.atlassian.net/browse/SC-3381)

## About
A high-contrast palette needs to be made available along with dark mode / light mode.

## Associated Pull Requests
https://github.com/epcpower/zap-master/pull/121
https://github.com/epcpower/libEpcCommonQt/pull/24

## Checklist
N/A

## Reproduction Steps
N/A



## Validation
1. In `Zap-Master`, checkout branch `SC-3381`
2. in `libEpcCommonQt`, checkout branch `SC-3381`
3. in `kanoopGuiQt`, checkout branch `feature/epc-ss`
4. Run application
5. Select `Edit`, then select `Preferences`
6. Select `Display`, then select `High Contrast`. Verify application is in `High Contrast` mode

![image](https://github.com/user-attachments/assets/50aed8ab-d017-4b64-bc2c-1e21165a6b61)

7. Switch between themes. Verify application switches between themes
8. Select `High Contrast` mode and close the application
9. Reopen `Zap-Master` and verify it is opened in `High Contrast` mode