### PR TITLE
fix(SC-5162): stop Label from baking palette colors into stylesheet

### DIFF
--- a/include/Kanoop/gui/widgets/label.h
+++ b/include/Kanoop/gui/widgets/label.h
@@ -88,6 +88,8 @@ private:
 
     QColor _backgroundColor;
     QColor _foregroundColor;
+    bool _backgroundExplicitlySet = false;
+    bool _foregroundExplicitlySet = false;
 };
 
 #endif // LABEL_H

--- a/src/gui/widgets/label.cpp
+++ b/src/gui/widgets/label.cpp
@@ -20,8 +20,6 @@ void Label::commonInit()
 {
     _backgroundColor = palette().color(QPalette::Window);
     _foregroundColor = palette().color(QPalette::Text);
-    setBackgroundColor(_backgroundColor);
-    setForegroundColor(_foregroundColor);
 }
 
 void Label::setFontPointSize(int size)
@@ -41,32 +39,40 @@ void Label::setFontPixelSize(int size)
 void Label::setForegroundColor(const QColor &color)
 {
     _foregroundColor = color;
+    _foregroundExplicitlySet = true;
     Label::applyStylesheet();
 }
 
 void Label::setBackgroundColor(const QColor &color)
 {
     _backgroundColor = color;
+    _backgroundExplicitlySet = true;
     Label::applyStylesheet();
 }
 
 void Label::setDefaultForegroundColor()
 {
     _foregroundColor = palette().color(QPalette::Text);
+    _foregroundExplicitlySet = false;
     applyStylesheet();
 }
 
 void Label::setDefaultBackgroundColor()
 {
     _backgroundColor = palette().color(QPalette::Window);
+    _backgroundExplicitlySet = false;
     applyStylesheet();
 }
 
 void Label::applyStylesheet()
 {
     StyleSheet<QLabel> ss;
-    ss.setProperty(SP_Color, _foregroundColor);
-    ss.setProperty(SP_BackgroundColor, _backgroundColor);
+    if(_foregroundExplicitlySet) {
+        ss.setProperty(SP_Color, _foregroundColor);
+    }
+    if(_backgroundExplicitlySet) {
+        ss.setProperty(SP_BackgroundColor, _backgroundColor);
+    }
     setStyleSheet(ss.toString());
 }
 


### PR DESCRIPTION
## Summary
- Label's `commonInit()` was capturing `QPalette::Window` at construction time and writing it into an inline stylesheet, freezing the white background even when dark mode was later applied
- Now only include foreground/background in the stylesheet when explicitly set via `setForegroundColor()`/`setBackgroundColor()`
- Fixes white-background labels ("Host Address:", "CAN Device:") visible in Pulse dark mode

## Test plan
- [ ] Build Pulse in dark mode, verify connection profile selector labels no longer have white backgrounds
- [ ] Verify labels with explicitly set colors (e.g. warning labels) still display their custom colors
- [ ] Verify `setDefaultForegroundColor()`/`setDefaultBackgroundColor()` reset to palette-inherited behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)