### PR TITLE
story(SC-5144): fix FlowLayout local variable shadowing

### DIFF
--- a/include/Kanoop/gui/widgets/flowlayout.h
+++ b/include/Kanoop/gui/widgets/flowlayout.h
@@ -1,0 +1,28 @@
+#ifndef FLOWLAYOUT_H
+#define FLOWLAYOUT_H
+
+#include <QGridLayout>
+#include <Kanoop/gui/libkanoopgui.h>
+
+class LIBKANOOPGUI_EXPORT FlowLayout : public QGridLayout
+{
+    Q_OBJECT
+public:
+    explicit FlowLayout(QWidget *parent = nullptr);
+
+    void addWidget(QWidget* widget);
+
+    int maxColumns() const { return _maxColumns; }
+    void setMaxColumns(int value) { _maxColumns = value; }
+
+    void compact();
+    void clear();
+
+private:
+    int _maxColumns;
+
+signals:
+
+};
+
+#endif // FLOWLAYOUT_H

--- a/src/gui/widgets/flowlayout.cpp
+++ b/src/gui/widgets/flowlayout.cpp
@@ -1,0 +1,40 @@
+#include "widgets/flowlayout.h"
+#include <Kanoop/log.h>
+#include <QWidget>
+
+FlowLayout::FlowLayout(QWidget *parent) :
+    QGridLayout{parent},
+    _maxColumns(15)
+{
+}
+
+void FlowLayout::addWidget(QWidget *widget)
+{
+    int currentCount = count();
+    int row = currentCount / _maxColumns;
+    int col = currentCount - (row * _maxColumns);
+    setColumnMinimumWidth(col, widget->width() + horizontalSpacing());
+    QGridLayout::addWidget(widget, row, col);
+
+    int width = (widget->width() * _maxColumns) + (horizontalSpacing() * _maxColumns);
+    int height = (widget->height() * (row + 1)) + (verticalSpacing() * (row + 1));
+
+    setGeometry(QRect(0, 0, width, height));
+}
+
+void FlowLayout::compact()
+{
+    int row = rowCount() - 1;
+    int col = columnCount() - 1;
+    if(row >= 0 && col >= 0) {
+        addItem(new QSpacerItem(1, 1, QSizePolicy::Expanding, QSizePolicy::Fixed), row, col);
+    }
+}
+
+void FlowLayout::clear()
+{
+    while(count() > 0) {
+        QLayoutItem* item = takeAt(0);
+        delete item->widget();
+    }
+}


### PR DESCRIPTION
## Summary
- Fix local `_maxColumns` redeclaration in `FlowLayout::addWidget()` that shadowed the member variable, making `setMaxColumns()` ineffective
- Move `flowlayout.cpp` from `include/` to `src/` where it belongs

## Test plan
- [ ] Build passes
- [ ] `setMaxColumns()` now correctly controls column count in FlowLayout

🤖 Generated with [Claude Code](https://claude.com/claude-code)