### PR TITLE
Reparent GuiSettings onto AppSettings (KanoopCommonQt)

### DIFF
--- a/include/Kanoop/gui/guisettings.h
+++ b/include/Kanoop/gui/guisettings.h
@@ -10,10 +10,9 @@
 ******************************************************************************************/
 #ifndef GUISETTINGS_H
 #define GUISETTINGS_H
-#include <QObject>
-#include <QSettings>
 #include <QWidget>
 #include <Kanoop/gui/libkanoopgui.h>
+#include <Kanoop/utility/appsettings.h>
 
 class QHeaderView;
 class QSplitter;
@@ -23,14 +22,14 @@ class TreeViewBase;
 /**
  * @brief Persistent GUI settings storage for widget geometry, header states, and directories.
  *
- * GuiSettings wraps QSettings to provide typed, named accessors for common GUI state
- * such as window positions, sizes, splitter states, header view states, and last-used
- * directories.  Subclass to add application-specific settings.
+ * GuiSettings extends AppSettings with typed accessors for common GUI state such as
+ * window positions, sizes, splitter states, header view states, and tree view state.
+ * Subclass to add application-specific settings.
  *
  * A process-wide singleton can be registered with setGlobalInstance() and retrieved
  * with globalInstance().
  */
-class LIBKANOOPGUI_EXPORT GuiSettings : public QObject
+class LIBKANOOPGUI_EXPORT GuiSettings : public AppSettings
 {
     Q_OBJECT
 
@@ -127,93 +126,6 @@ public:
     void restoreTreeViewState(TreeViewBase* treeView);
 
     /**
-     * @brief Persist an arbitrary string value.
-     * @param key Settings key
-     * @param value String to save
-     */
-    void setStringValue(const QString& key, const QString& value) { _settings.setValue(key, value); }
-
-    /**
-     * @brief Retrieve an arbitrary string value.
-     * @param key Settings key
-     * @return Saved string, or empty string if not found
-     */
-    QString getStringValue(const QString& key) const { return _settings.value(key).toString(); }
-
-    /**
-     * @brief Persist an arbitrary QVariant value.
-     * @param key Settings key
-     * @param value Variant to save
-     */
-    void setVariantValue(const QString& key, const QVariant& value) { _settings.setValue(key, value); }
-
-    /**
-     * @brief Retrieve an arbitrary QVariant value.
-     * @param key Settings key
-     * @return Saved variant, or invalid QVariant if not found
-     */
-    QVariant getVariantValue(const QString& key) const { return _settings.value(key); }
-
-    /**
-     * @brief Persist an arbitrary byte array value.
-     * @param key Settings key
-     * @param value Byte array to save
-     */
-    void setByteArrayValue(const QString& key, const QByteArray& value) { _settings.setValue(key, value); }
-
-    /**
-     * @brief Retrieve an arbitrary byte array value.
-     * @param key Settings key
-     * @return Saved byte array, or empty array if not found
-     */
-    QByteArray getByteArrayValue(const QString& key) const { return _settings.value(key).toByteArray(); }
-
-    /**
-     * @brief Return the maximum number of recent files to track.
-     * @return Maximum recent file count
-     */
-    int maxRecentFiles() const { return _maxRecentFiles; }
-
-    /**
-     * @brief Set the maximum number of recent files to track.
-     * @param value Maximum recent file count
-     */
-    void setMaxRecentFiles(int value) { _maxRecentFiles = value; }
-
-    /**
-     * @brief Return the last directory used for a given file extension.
-     * @param extension File extension (without leading dot)
-     * @return Last directory path string
-     */
-    QString lastDirectory(const QString& extension) const { return _settings.value(makeFileTypeKey(KEY_LAST_DIRECTORY, extension)).toString(); }
-
-    /**
-     * @brief Return the last directory used for a given file-type integer.
-     * @param fileType Application-defined file type integer
-     * @return Last directory path string
-     */
-    QString lastDirectory(int fileType) const { return _settings.value(makeFileTypeKey(KEY_LAST_DIRECTORY, fileType)).toString(); }
-
-    /**
-     * @brief Save the last directory used for a given file extension.
-     * @param extension File extension (without leading dot)
-     * @param value Directory path to save
-     */
-    virtual void saveLastDirectory(const QString& extension, const QString& value) { _settings.setValue(makeFileTypeKey(KEY_LAST_DIRECTORY, extension), value); }
-
-    /**
-     * @brief Save the last directory used for a given file-type integer.
-     * @param fileType Application-defined file type integer
-     * @param value Directory path to save
-     */
-    virtual void saveLastDirectory(int fileType, const QString& value) { _settings.setValue(makeFileTypeKey(KEY_LAST_DIRECTORY, fileType), value); }
-
-    /**
-     * @brief Synchronize settings file to disk and reload any changed values
-     */
-    void sync();
-
-    /**
      * @brief Return the persisted font size.
      * @return Font point size, or 0 if not set
      */
@@ -229,48 +141,18 @@ public:
      * @brief Return the process-wide GuiSettings singleton.
      * @return Global GuiSettings instance, or nullptr if not set
      */
-    static GuiSettings* globalInstance();
-
-    /**
-     * @brief Set the process-wide GuiSettings singleton.
-     * @param value Instance to register as global
-     */
-    static void setGlobalInstance(GuiSettings* value) { _globalInstance = value; }
-
-signals:
-    /** @brief Emitted when any setting value changes. */
-    void settingsChanged();
+    static GuiSettings* globalInstance() { return static_cast<GuiSettings*>(AppSettings::globalInstance()); }
 
 protected:
-    /** @brief Build a settings key prefixed with the application key. */
-    static QString makeStandardKey(const QString& key) { return QString("%1/%2").arg(KEY_APP).arg(key); }
-    /** @brief Build a compound settings key from two parts. */
-    static QString makeKey(const QString& key, const QString& subKey) { return QString("%1/%2").arg(key).arg(subKey); }
-    /** @brief Build a settings key based on a QObject's identity. */
-    static QString makeObjectKey(const QObject* object);
-    /** @brief Build a settings key based on a file extension. */
-    static QString makeFileTypeKey(const QString& key, const QString& extension);
-    /** @brief Build a settings key based on a file-type integer. */
-    static QString makeFileTypeKey(const QString& key, int fileType);
-    /** @brief Build a compound settings key from a base key and a QObject. */
-    static QString makeCompoundObjectKey(const QString& key, const QObject* object);
-
     /** @brief Override to ensure sane default values on first run. */
-    virtual void ensureValidDefaults();
+    virtual void ensureValidDefaults() override;
 
-    /** @brief Underlying QSettings storage. */
-    QSettings _settings;
-
-    /** @brief Settings key for the application group. */
-    static const QString KEY_APP;
     /** @brief Settings key for the saved font size. */
     static const QString KEY_FONT_SIZE;
     /** @brief Settings key for the horizontal header state. */
     static const QString KEY_HEADER_STATE_HORIZ;
     /** @brief Settings key for the vertical header state. */
     static const QString KEY_HEADER_STATE_VERT;
-    /** @brief Settings key for the last-used directory. */
-    static const QString KEY_LAST_DIRECTORY;
     /** @brief Settings key for the last widget position. */
     static const QString KEY_LAST_WIDGET_POS;
     /** @brief Settings key for the last widget size. */
@@ -285,16 +167,6 @@ protected:
     static const QString KEY_SPLITTER_STATE_VERT;
     /** @brief Settings key for the tree view expansion state. */
     static const QString KEY_TREEVIEW_STATE;
-
-private:
-    /** @brief Convert a list of UUIDs to a list of strings for persistence. */
-    static QStringList uuidListToStringList(const QList<QUuid>& uuids);
-    /** @brief Convert a list of strings back to UUIDs. */
-    static QList<QUuid> stringListToUuidList(const QStringList& values);
-
-    int _maxRecentFiles;
-
-    static GuiSettings* _globalInstance;
 };
 
 #endif // GUISETTINGS_H

--- a/src/gui/guisettings.cpp
+++ b/src/gui/guisettings.cpp
@@ -13,23 +13,19 @@
 #include "headerstate.h"
 #include "treeviewbase.h"
 #include <QApplication>
-#include <QCoreApplication>
+#include <QFont>
 #include <QHeaderView>
 #include <QMdiSubWindow>
-#include <QMutex>
 #include <QScreen>
 #include <QSplitter>
 #include <QTableView>
-#include <QUuid>
 #include <Kanoop/log.h>
 #include <Kanoop/geometry/rectangle.h>
 #include <Kanoop/geometry/size.h>
 
-const QString GuiSettings::KEY_APP                          = "app";
 const QString GuiSettings::KEY_FONT_SIZE                    = "font_size";
 const QString GuiSettings::KEY_HEADER_STATE_HORIZ           = "header_state_h";
 const QString GuiSettings::KEY_HEADER_STATE_VERT            = "header_state_v";
-const QString GuiSettings::KEY_LAST_DIRECTORY               = "last_dir";
 const QString GuiSettings::KEY_LAST_WIDGET_POS              = "widget_pos";
 const QString GuiSettings::KEY_LAST_WIDGET_SIZE             = "widget_size";
 const QString GuiSettings::KEY_MODEL_HEADER_STATE_HORIZ     = "model_header_state_h";
@@ -38,11 +34,8 @@ const QString GuiSettings::KEY_SPLITTER_STATE_HORIZ         = "splitter_state_h"
 const QString GuiSettings::KEY_SPLITTER_STATE_VERT          = "splitter_state_v";
 const QString GuiSettings::KEY_TREEVIEW_STATE               = "treeview_state";
 
-GuiSettings* GuiSettings::_globalInstance                   = nullptr;
-
 GuiSettings::GuiSettings() :
-    _settings(QSettings::IniFormat, QSettings::UserScope, QCoreApplication::instance()->organizationName(), QCoreApplication::instance()->applicationName()),
-    _maxRecentFiles(10)
+    AppSettings()
 {
 }
 
@@ -213,70 +206,9 @@ void GuiSettings::restoreTreeViewState(TreeViewBase *treeView)
     treeView->restoreState(state);
 }
 
-void GuiSettings::sync()
-{
-    _settings.sync();
-}
-
-GuiSettings *GuiSettings::globalInstance()
-{
-    static QMutex _lock;
-    _lock.lock();
-    if(_globalInstance == nullptr) {
-        _globalInstance = new GuiSettings;
-    }
-    _lock.unlock();
-    return _globalInstance;
-}
-
-QString GuiSettings::makeObjectKey(const QObject *object)
-{
-    QString result = object->objectName();
-    if(object->parent() != nullptr) {
-        result.prepend(object->parent()->objectName());
-    }
-    return result;
-}
-
-QString GuiSettings::makeFileTypeKey(const QString &key, const QString &extension)
-{
-    QString fixed = extension;
-    fixed.removeIf([extension](const QChar& it) { return it.isPunct() || it.isSpace(); });
-    return QString("%1/%2").arg(key, fixed);
-}
-
-QString GuiSettings::makeFileTypeKey(const QString& key, int fileType)
-{
-    return QString("%1/%2").arg(key, QString("type_%1").arg(fileType));
-}
-
-QString GuiSettings::makeCompoundObjectKey(const QString &key, const QObject *object)
-{
-    QString objectKey = makeKey(key, makeObjectKey(object));
-    return objectKey;
-}
-
 void GuiSettings::ensureValidDefaults()
 {
     if(fontSize() == 0) {
         setFontSize(QFont().pointSize());
     }
-}
-
-QStringList GuiSettings::uuidListToStringList(const QList<QUuid> &uuids)
-{
-    QStringList result;
-    for(const QUuid& uuid : uuids) {
-        result.append(uuid.toString(QUuid::WithoutBraces));
-    }
-    return result;
-}
-
-QList<QUuid> GuiSettings::stringListToUuidList(const QStringList &values)
-{
-    QList<QUuid> result;
-    for(const QString& value : values) {
-        result.append(QUuid::fromString(value));
-    }
-    return result;
 }


### PR DESCRIPTION
## Summary
- Reparents `GuiSettings` from `QObject` onto the new `AppSettings` base added in `KanoopCommonQt#feature/settings`.
- Removes migrated members (QSettings store, generic accessors, last-directory tracking, `maxRecentFiles`, `sync`, `settingsChanged`, key helpers, `KEY_APP`/`KEY_LAST_DIRECTORY`) — they are now inherited.
- `GuiSettings` keeps only widget/splitter/header/tree-view state and font-size members.
- **Behavior change:** `GuiSettings::globalInstance()` no longer auto-creates a vanilla `GuiSettings` when unset; it returns `nullptr`. All in-tree callsites already null-check, and applications register their own subclass via `setGlobalInstance()` at startup.

## Test plan
- [ ] Depends on `KanoopCommonQt#feature/settings` — merge that first
- [ ] `cmake --build` succeeds for KanoopGuiQt
- [ ] Downstream `kiosk` builds; widget geometry, splitter state, header state, font size all persist as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)