### PR TITLE
feat(stylesheet): support compound pseudo-states and abstract widget …

### DIFF
--- a/include/Kanoop/gui/utility/stylesheet.h
+++ b/include/Kanoop/gui/utility/stylesheet.h
@@ -30,9 +30,7 @@ public:
     /** @brief Construct and capture the widget class name as the CSS selector. */
     StyleSheet()
     {
-        T* t = new T();
-        _typeName = t->metaObject()->className();
-        delete t;
+        _typeName = T::staticMetaObject.className();
     }
 
     /**
@@ -103,10 +101,22 @@ public:
     void setBorder(int widthPx, const QColor& topLeft, const QColor& bottomRight);
 
     /**
-     * @brief Set the pseudo-state selector (e.g., PS_Hover, PS_Checked).
+     * @brief Set the pseudo-state selector (e.g., PS_Hover, PS_Checked), replacing any previous value(s).
      * @param value Pseudo-state enum value
      */
-    void setPseudoState(StyleSheetPseudoState value) { _pseudoState = value; }
+    void setPseudoState(StyleSheetPseudoState value) { _pseudoStates = { value }; }
+
+    /**
+     * @brief Append a pseudo-state to the selector chain (e.g., :checked:disabled).
+     * @param value Pseudo-state enum value to append
+     */
+    void addPseudoState(StyleSheetPseudoState value) { _pseudoStates.append(value); }
+
+    /**
+     * @brief Set the full pseudo-state chain at once.
+     * @param values Ordered list of pseudo-states; emitted as `:value1:value2...`
+     */
+    void setPseudoStates(const QList<StyleSheetPseudoState>& values) { _pseudoStates = values; }
 
     /**
      * @brief Set the sub-control selector string (e.g., "::handle").
@@ -118,7 +128,7 @@ public:
      * @brief Set the sub-control selector from a typed enum value.
      * @param value Sub-control enum value (e.g., SC_Indicator)
      */
-    void setSubControl(StyleSheetSubControl value) { _subControl = StyleSheetStrings::getSubControlString(value); }
+    void setSubControl(StyleSheetSubControl value);
 
     /**
      * @brief Render all accumulated properties into a complete stylesheet rule.
@@ -132,8 +142,8 @@ public:
 
     /** @brief Accumulated property/value pairs for the stylesheet rule. */
     QMap<StyleSheetProperty, QString> _properties;
-    /** @brief Pseudo-state selector applied to the rule (PS_Invalid = none). */
-    StyleSheetPseudoState _pseudoState = PS_Invalid;
+    /** @brief Pseudo-state selectors applied to the rule, in order (empty = none). */
+    QList<StyleSheetPseudoState> _pseudoStates;
     /** @brief Sub-control selector string (empty = none). */
     QString _subControl;
 };

--- a/src/gui/utility/stylesheet.cpp
+++ b/src/gui/utility/stylesheet.cpp
@@ -1,4 +1,5 @@
 #include "utility/stylesheet.h"
+#include <QAbstractItemView>
 #include <QGradient>
 #include <QFrame>
 #include <QLabel>
@@ -49,8 +50,8 @@ QString StyleSheet<T>::toString() const
     if(_subControl.isEmpty() == false) {
         output << "::" << _subControl;
     }
-    if(_pseudoState != PS_Invalid) {
-        output << ':' << StyleSheetStrings::getPseudoStateString(_pseudoState);
+    for(StyleSheetPseudoState ps : _pseudoStates) {
+        output << ':' << StyleSheetStrings::getPseudoStateString(ps);
     }
     output << " {";
     QList<StyleSheetProperty> keys = _properties.keys();
@@ -100,7 +101,14 @@ void StyleSheet<T>::setBorder(int widthPx, const QColor& topLeft, const QColor& 
     setBorder(make(topLeft), make(bottomRight));
 }
 
+template<typename T>
+void StyleSheet<T>::setSubControl(StyleSheetSubControl value)
+{
+    _subControl = StyleSheetStrings::getSubControlString(value);
+}
+
 template class StyleSheet<QWidget>;
+template class StyleSheet<QAbstractItemView>;
 template class StyleSheet<QFrame>;
 template class StyleSheet<QGroupBox>;
 template class StyleSheet<QLabel>;


### PR DESCRIPTION
## Summary

Four related changes to `StyleSheet<T>`, all driven by a downstream refactor in `libEpcCommonQt` that wants to express the checkbox / item-view indicator stylesheets through `StyleSheet<T>` end-to-end:

1. **Compound pseudo-states** — replace the single `_pseudoState` value with `_pseudoStates` (`QList<StyleSheetPseudoState>`) so selectors like `:checked:disabled` and `:indeterminate:disabled` can be expressed. Adds `addPseudoState()` and `setPseudoStates()`. `setPseudoState()` keeps replace semantics so existing call sites are unaffected.
2. **Abstract widget classes** — `StyleSheet<T>::StyleSheet()` did `new T(); className(); delete t;`, which can't compile for abstract `QAbstractItemView`. Switched to `T::staticMetaObject.className()` — works for abstract types, cleaner, and avoids an unnecessary allocation.
3. **Cross-DLL link error fix for `setSubControl(StyleSheetSubControl)`** — the typed overload added in #17 was inline in the header, and its body dereferenced `StyleSheetStrings::_SubControlToStringMap`, a static member of a non-exported internal helper class. On Linux MinGW this links because all symbols are exported by default; on Windows MinGW it fails with `undefined symbol: StyleSheetStrings::_SubControlToStringMap` in any downstream DLL that calls it. Moved the body into `stylesheet.cpp` so the static lookup happens in the same translation unit where the map is defined. The other typed string accessors (`getPropertyString`, `getPseudoStateString`) don't hit this because they're only invoked from inside `toString()`, which already lives in the `.cpp`.
4. **`QAbstractItemView` instantiation** — added `template class StyleSheet<QAbstractItemView>;` so downstream code can write `StyleSheet<QAbstractItemView>` directly. Common pattern for `::indicator` rules in tree/table views.

## Why now

While migrating `libEpcCommonQt` to remove hardcoded CSS literals from `epcapplication.cpp` and `highcontraststylesheet.cpp` in favor of the typed `StyleSheet<T>` API (review feedback on epcpower/libEpcCommonQt#238), all four gaps surfaced in the same change. The link bug in particular is a latent issue from #17 — anyone outside KanoopGuiQt who tried to use the typed `setSubControl` overload would have hit it.

## Test plan

- [x] Windows MinGW build clean (KanoopGuiQt + downstream `libEpcCommonQt` consumer)
- [ ] Linux build (no API changes that would behave differently; existing `setPseudoState()` callers unaffected)
- [x] Downstream consumer builds compound-state rules: `StyleSheet<QCheckBox>` with `addPseudoState(PS_Checked); addPseudoState(PS_Disabled);` renders `QCheckBox::indicator:checked:disabled { ... }` as expected

## Compatibility

- `setPseudoState(value)` now sets `_pseudoStates = { value }` instead of overwriting a scalar. Behaviorally identical for existing callers.
- All existing inline behavior preserved except the typed `setSubControl(StyleSheetSubControl)` overload, which is now resolved at link time instead of inline. No source-level change for callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)