### PR TITLE
chore(SC-5421): upgrade GitHub Actions to node24-compatible versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,12 +25,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: KanoopGuiQt
 
       - name: Checkout KanoopCommonQt
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: StevePunak/KanoopCommonQt
           path: KanoopCommonQt
@@ -74,7 +74,7 @@ jobs:
 
       - name: Upload Pages artifact
         if: github.ref == 'refs/heads/master'
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: KanoopGuiQt/docs/html
 
@@ -91,4 +91,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Jira Story

[SC-5421](https://epcpower.atlassian.net/browse/SC-5421) — Investigate and fix Node.js deprecation warnings in CI across all repositories

## About

Updates four GitHub Actions in `ci.yaml` from deprecated Node.js runtimes to Node.js 24-compatible versions, addressing GitHub's deprecation of Node.js 20 in Actions runners. The `actions/checkout` step appears twice (once for this repo, once for the KanoopCommonQt dependency checkout) and is updated in both places.

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` (×2) | `@v4` | `@v5` |
| `actions/upload-pages-artifact` | `@v3` | `@v4` |
| `actions/deploy-pages` | `@v4` | `@v5` |

## Validation

Confirm the CI run completes without Node.js deprecation warnings in any step log.