### PR TITLE
story(SC-5673): include moc files in source files for faster incremental builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ file(GLOB_RECURSE PROJ_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/src/*.qrc"
 )
 
-qt_add_library(${PROJ} ${PROJ_SOURCES})
+qt_add_library(${PROJ} MANUAL_FINALIZATION ${PROJ_SOURCES})
 
 target_compile_options(${PROJ} PRIVATE -Wextra -Wall -Werror)
 
@@ -55,6 +55,17 @@ add_compile_definitions(QT_DISABLE_DEPRECATED_BEFORE=0x060000)  # Disables all t
 if (DEFINED $ENV{KYBER_OUTPUT_PREFIX})
     set(KANOOP_INSTALL_PREFIX "$ENV{KYBER_OUTPUT_PREFIX}/")
 endif()
+
+# Suppress Qt's metatype JSON generation. Nothing in this project consumes it
+# (no QML / qmltyperegistrar), and `moc --collect-json` fails on a clean build
+# for the path-prefixed manually-included moc files this library uses (split
+# include/ + src/ layout, SC-5673). Pointing INTERFACE_QT_META_TYPES_BUILD_FILE
+# at an empty file short-circuits qt6_extract_metatypes for this target and any
+# consumer that reads it. Paired with MANUAL_FINALIZATION + qt_finalize_target.
+set(_no_metatypes "${CMAKE_CURRENT_BINARY_DIR}/${PROJ}_no_metatypes.json")
+file(TOUCH "${_no_metatypes}")
+set_target_properties(${PROJ} PROPERTIES INTERFACE_QT_META_TYPES_BUILD_FILE "${_no_metatypes}")
+qt_finalize_target(${PROJ})
 
 install(TARGETS ${PROJ} LIBRARY DESTINATION "${KANOOP_INSTALL_PREFIX}${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/Kanoop" DESTINATION "${KANOOP_INSTALL_PREFIX}${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}" FILES_MATCHING PATTERN "*.h")

--- a/src/gui/abstractitemmodel.cpp
+++ b/src/gui/abstractitemmodel.cpp
@@ -635,3 +635,5 @@ QString AbstractItemModel::toString(const QModelIndex &index, bool includeText)
 
 
 
+
+#include "Kanoop/gui/moc_abstractitemmodel.cpp"

--- a/src/gui/abstractlistmodel.cpp
+++ b/src/gui/abstractlistmodel.cpp
@@ -56,3 +56,5 @@ QVariant AbstractListModel::data(const QModelIndex &index, int role) const
     return result;
 }
 
+
+#include "Kanoop/gui/moc_abstractlistmodel.cpp"

--- a/src/gui/abstracttablemodel.cpp
+++ b/src/gui/abstracttablemodel.cpp
@@ -81,3 +81,5 @@ void AbstractTableModel::columnChangedAtRowIndex(const QModelIndex &rowIndex, in
     }
 }
 
+
+#include "Kanoop/gui/moc_abstracttablemodel.cpp"

--- a/src/gui/abstracttreemodel.cpp
+++ b/src/gui/abstracttreemodel.cpp
@@ -30,3 +30,5 @@ void AbstractTreeModel::columnChangedAtRowIndex(const QModelIndex &rowIndex, int
         emit dataChanged(columnIndex, columnIndex);
     }
 }
+
+#include "Kanoop/gui/moc_abstracttreemodel.cpp"

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -6,3 +6,5 @@ Application::Application(int& argc, char* argv[], const QString& applicationName
 {
     setApplicationName(applicationName);
 }
+
+#include "Kanoop/gui/moc_application.cpp"

--- a/src/gui/columnsettingsdialog.cpp
+++ b/src/gui/columnsettingsdialog.cpp
@@ -36,3 +36,5 @@ void ColumnSettingsDialog::okClicked()
          _headers.setHeaderVisible(item->type(), item->checkState() == Qt::Checked);
     }
 }
+
+#include "moc_columnsettingsdialog.cpp"

--- a/src/gui/complexwidget.cpp
+++ b/src/gui/complexwidget.cpp
@@ -115,3 +115,5 @@ void ComplexWidget::onSplitterMoved()
 }
 
 
+
+#include "Kanoop/gui/moc_complexwidget.cpp"

--- a/src/gui/dialog.cpp
+++ b/src/gui/dialog.cpp
@@ -390,3 +390,5 @@ void Dialog::onCancelClicked()
     cancelClicked();
     reject();
 }
+
+#include "Kanoop/gui/moc_dialog.cpp"

--- a/src/gui/graphics/graphicsscene.cpp
+++ b/src/gui/graphics/graphicsscene.cpp
@@ -5,3 +5,5 @@ GraphicsScene::GraphicsScene(QObject* parent) :
     LoggingBaseClass("gfx")
 {
 }
+
+#include "Kanoop/gui/graphics/moc_graphicsscene.cpp"

--- a/src/gui/graphics/graphicsview.cpp
+++ b/src/gui/graphics/graphicsview.cpp
@@ -122,3 +122,5 @@ bool GraphicsView::processMouseMoveEvent(QMouseEvent* event)
 
 
 
+
+#include "Kanoop/gui/graphics/moc_graphicsview.cpp"

--- a/src/gui/graphics/qobjectgraphicsitem.cpp
+++ b/src/gui/graphics/qobjectgraphicsitem.cpp
@@ -2,3 +2,5 @@
 
 QObjectGraphicsItem::QObjectGraphicsItem(QObject* parent) :
     QObject(parent) {}
+
+#include "Kanoop/gui/graphics/moc_qobjectgraphicsitem.cpp"

--- a/src/gui/guisettings.cpp
+++ b/src/gui/guisettings.cpp
@@ -219,3 +219,5 @@ void GuiSettings::ensureValidDefaults()
         setFontSize(QFont().pointSize());
     }
 }
+
+#include "Kanoop/gui/moc_guisettings.cpp"

--- a/src/gui/listview.cpp
+++ b/src/gui/listview.cpp
@@ -77,3 +77,5 @@ void ListView::onCurrentSelectionChanged(const QModelIndex& current, const QMode
     emit currentIndexChanged(current);
     emit currentSelectionChanged();
 }
+
+#include "Kanoop/gui/moc_listview.cpp"

--- a/src/gui/mainwindowbase.cpp
+++ b/src/gui/mainwindowbase.cpp
@@ -175,3 +175,5 @@ void MainWindowBase::onSpliltterMoved()
 {
     GuiSettings::globalInstance()->saveLastSplitterState(static_cast<QSplitter*>(sender()));
 }
+
+#include "Kanoop/gui/moc_mainwindowbase.cpp"

--- a/src/gui/mdiarea.cpp
+++ b/src/gui/mdiarea.cpp
@@ -69,3 +69,5 @@ QMdiSubWindow* MdiArea::getNextSubWindowInCycle(bool forward)
 
     return nullptr;  // should not happen
 }
+
+#include "Kanoop/gui/moc_mdiarea.cpp"

--- a/src/gui/mdisubwindow.cpp
+++ b/src/gui/mdisubwindow.cpp
@@ -60,3 +60,5 @@ void MdiSubWindow::onPreferencesChanged()
         }
     }
 }
+
+#include "Kanoop/gui/moc_mdisubwindow.cpp"

--- a/src/gui/mdiwindow.cpp
+++ b/src/gui/mdiwindow.cpp
@@ -102,3 +102,5 @@ void MdiWindow::onSubWindowClosing()
     }
 }
 
+
+#include "Kanoop/gui/moc_mdiwindow.cpp"

--- a/src/gui/tabbar.cpp
+++ b/src/gui/tabbar.cpp
@@ -17,3 +17,5 @@ void TabBar::mousePressEvent(QMouseEvent* event)
     }
     QTabBar::mousePressEvent(event);
 }
+
+#include "Kanoop/gui/moc_tabbar.cpp"

--- a/src/gui/tableviewbase.cpp
+++ b/src/gui/tableviewbase.cpp
@@ -329,3 +329,5 @@ void TableViewBase::onResetColumnsClicked()
     GuiSettings::globalInstance()->saveLastHeaderState(horizontalHeader(), sourceModel());
 }
 
+
+#include "Kanoop/gui/moc_tableviewbase.cpp"

--- a/src/gui/treeselectionmodel.cpp
+++ b/src/gui/treeselectionmodel.cpp
@@ -41,3 +41,5 @@ void TreeSelectionModel::select(const QItemSelection& selection, SelectionFlags 
         QItemSelectionModel::select(selection, command);
     }
 }
+
+#include "Kanoop/gui/moc_treeselectionmodel.cpp"

--- a/src/gui/treeviewbase.cpp
+++ b/src/gui/treeviewbase.cpp
@@ -691,3 +691,5 @@ QModelIndexList TreeViewBase::indexesOfUuid(const QUuid& uuid) const
     return result;
 }
 
+
+#include "Kanoop/gui/moc_treeviewbase.cpp"

--- a/src/gui/widgets/accordionwidget.cpp
+++ b/src/gui/widgets/accordionwidget.cpp
@@ -170,3 +170,5 @@ void AccordionWidget::onPreferencesChanged()
     setFont(newFont);
 }
 
+
+#include "Kanoop/gui/widgets/moc_accordionwidget.cpp"

--- a/src/gui/widgets/accordionwidgetprivate.cpp
+++ b/src/gui/widgets/accordionwidgetprivate.cpp
@@ -80,3 +80,5 @@ void DropDownButton::paintEvent(QPaintEvent* event)
     QPixmap pm = _expanded ? _down : _up;
     painter.drawPixmap(paintRect, pm);
 }
+
+#include "moc_accordionwidgetprivate.cpp"

--- a/src/gui/widgets/buttonlabel.cpp
+++ b/src/gui/widgets/buttonlabel.cpp
@@ -114,3 +114,5 @@ void ButtonLabel::onButtonClicked()
     emit activeChanged();
     emit clicked();
 }
+
+#include "Kanoop/gui/widgets/moc_buttonlabel.cpp"

--- a/src/gui/widgets/checkbox.cpp
+++ b/src/gui/widgets/checkbox.cpp
@@ -22,3 +22,5 @@ void CheckBox::mousePressEvent(QMouseEvent* event)
         QCheckBox::mousePressEvent(event);
     }
 }
+
+#include "Kanoop/gui/widgets/moc_checkbox.cpp"

--- a/src/gui/widgets/checkboxdesignerplugin.cpp
+++ b/src/gui/widgets/checkboxdesignerplugin.cpp
@@ -12,3 +12,5 @@ QWidget* CheckBoxDesignerPlugin::createWidget(QWidget* parent)
 {
     return new CheckBox("Some checkbox", parent);
 }
+
+#include "moc_checkboxdesignerplugin.cpp"

--- a/src/gui/widgets/combobox.cpp
+++ b/src/gui/widgets/combobox.cpp
@@ -43,3 +43,5 @@ void ComboBox::focusOutEvent(QFocusEvent* event)
     emit lostFocus();
 }
 
+
+#include "Kanoop/gui/widgets/moc_combobox.cpp"

--- a/src/gui/widgets/datetimeedit.cpp
+++ b/src/gui/widgets/datetimeedit.cpp
@@ -7,3 +7,5 @@ DateTimeEdit::DateTimeEdit(QWidget *parent) :
     QDateTimeEdit{parent}
 {
 }
+
+#include "Kanoop/gui/widgets/moc_datetimeedit.cpp"

--- a/src/gui/widgets/designerplugininterfaces.cpp
+++ b/src/gui/widgets/designerplugininterfaces.cpp
@@ -24,3 +24,5 @@ QWidget* PushButtonDesignerPlugin::createWidget(QWidget* parent)
 {
     return new PushButton(parent);
 }
+
+#include "moc_designerplugininterfaces.cpp"

--- a/src/gui/widgets/flowlayout.cpp
+++ b/src/gui/widgets/flowlayout.cpp
@@ -38,3 +38,5 @@ void FlowLayout::clear()
         delete item->widget();
     }
 }
+
+#include "Kanoop/gui/widgets/moc_flowlayout.cpp"

--- a/src/gui/widgets/frame.cpp
+++ b/src/gui/widgets/frame.cpp
@@ -24,3 +24,5 @@ void Frame::setBackgroundColor(const QColor& color)
     setStyleSheet(ss.toString());
 }
 
+
+#include "Kanoop/gui/widgets/moc_frame.cpp"

--- a/src/gui/widgets/groupbox.cpp
+++ b/src/gui/widgets/groupbox.cpp
@@ -12,3 +12,5 @@ GroupBox::GroupBox(const QString& title, QWidget* parent) :
 {
 
 }
+
+#include "Kanoop/gui/widgets/moc_groupbox.cpp"

--- a/src/gui/widgets/iconlabel.cpp
+++ b/src/gui/widgets/iconlabel.cpp
@@ -68,3 +68,5 @@ void IconLabel::createLayout(const QString& text, const QIcon& icon)
 
     setLayout(layout);
 }
+
+#include "Kanoop/gui/widgets/moc_iconlabel.cpp"

--- a/src/gui/widgets/label.cpp
+++ b/src/gui/widgets/label.cpp
@@ -76,3 +76,5 @@ void Label::applyStylesheet()
     setStyleSheet(ss.toString());
 }
 
+
+#include "Kanoop/gui/widgets/moc_label.cpp"

--- a/src/gui/widgets/labeldesignerplugin.cpp
+++ b/src/gui/widgets/labeldesignerplugin.cpp
@@ -12,3 +12,5 @@ QWidget* LabelDesignerPlugin::createWidget(QWidget* parent)
 {
     return new Label("Label", parent);
 }
+
+#include "moc_labeldesignerplugin.cpp"

--- a/src/gui/widgets/lineedit.cpp
+++ b/src/gui/widgets/lineedit.cpp
@@ -26,3 +26,5 @@ void LineEdit::setBackgroundColor(const QColor& color)
     ss.setProperty(SP_BackgroundColor, color);
     setStyleSheet(ss.toString());
 }
+
+#include "Kanoop/gui/widgets/moc_lineedit.cpp"

--- a/src/gui/widgets/plaintextedit.cpp
+++ b/src/gui/widgets/plaintextedit.cpp
@@ -30,3 +30,5 @@ void PlainTextEdit::appendFormattedText(const QString& text, TextFlags flags, co
     QString result = html.toString();
     appendHtml(result);
 }
+
+#include "Kanoop/gui/widgets/moc_plaintextedit.cpp"

--- a/src/gui/widgets/playpausebutton.cpp
+++ b/src/gui/widgets/playpausebutton.cpp
@@ -71,3 +71,5 @@ void PlayPauseButton::setButtonSize(const QSize& min, const QSize& max, const QS
     _button->setMaximumSize(max);
     _button->setIconSize(icon);
 }
+
+#include "Kanoop/gui/widgets/moc_playpausebutton.cpp"

--- a/src/gui/widgets/pushbutton.cpp
+++ b/src/gui/widgets/pushbutton.cpp
@@ -156,3 +156,5 @@ void PushButton::makeStyleSheet()
 
     setStyleSheet(ss);
 }
+
+#include "Kanoop/gui/widgets/moc_pushbutton.cpp"

--- a/src/gui/widgets/sidebarwidget.cpp
+++ b/src/gui/widgets/sidebarwidget.cpp
@@ -124,3 +124,5 @@ void SidebarWidget::onItemClicked(const QModelIndex &index)
         emit itemClicked(itemType);
     }
 }
+
+#include "Kanoop/gui/widgets/moc_sidebarwidget.cpp"

--- a/src/gui/widgets/sidebarwidgetprivate.cpp
+++ b/src/gui/widgets/sidebarwidgetprivate.cpp
@@ -87,3 +87,5 @@ QRect SidebarPaintDelegate::textRectangle(const QStyleOptionViewItem &option) co
     QFontMetrics metrics(textFont(option));
     return metrics.boundingRect(option.rect, Qt::AlignCenter | Qt::TextWordWrap, option.text);
 }
+
+#include "moc_sidebarwidgetprivate.cpp"

--- a/src/gui/widgets/slider.cpp
+++ b/src/gui/widgets/slider.cpp
@@ -17,3 +17,5 @@ void Slider::mousePressEvent(QMouseEvent* event)
         QSlider::mousePressEvent(event);
     }
 }
+
+#include "Kanoop/gui/widgets/moc_slider.cpp"

--- a/src/gui/widgets/spinnerwidget.cpp
+++ b/src/gui/widgets/spinnerwidget.cpp
@@ -90,3 +90,5 @@ void SpinnerWidget::onSpinTimer()
     _index = _index < _pixmaps.count() - 1 ? _index + 1 : 0;
     update();
 }
+
+#include "Kanoop/gui/widgets/moc_spinnerwidget.cpp"

--- a/src/gui/widgets/statusbar.cpp
+++ b/src/gui/widgets/statusbar.cpp
@@ -64,3 +64,5 @@ void StatusBar::onDotTimerExpired()
         _dots = 0;
     }
 }
+
+#include "Kanoop/gui/widgets/moc_statusbar.cpp"

--- a/src/gui/widgets/tabwidget.cpp
+++ b/src/gui/widgets/tabwidget.cpp
@@ -9,3 +9,5 @@ TabWidget::TabWidget(QWidget *parent) :
     connect(tabBar, &TabBar::tabCustomContextMenuRequested, this, &TabWidget::tabCustomContextMenuRequested);
     setTabBar(tabBar);
 }
+
+#include "Kanoop/gui/widgets/moc_tabwidget.cpp"

--- a/src/gui/widgets/toastmanager.cpp
+++ b/src/gui/widgets/toastmanager.cpp
@@ -78,3 +78,5 @@ void ToastManager::closeToast()
     }
 }
 
+
+#include "Kanoop/gui/widgets/moc_toastmanager.cpp"

--- a/src/gui/widgets/toastwidget.cpp
+++ b/src/gui/widgets/toastwidget.cpp
@@ -91,3 +91,5 @@ void ToastWidget::onClick()
 {
     Log::logText(LVL_DEBUG, "Clicked");
 }
+
+#include "moc_toastwidget.cpp"

--- a/src/gui/widgets/widgetplugincollection.cpp
+++ b/src/gui/widgets/widgetplugincollection.cpp
@@ -17,3 +17,5 @@ QList<QDesignerCustomWidgetInterface*> WidgetPluginCollection::customWidgets() c
 {
     return _widgets;
 }
+
+#include "Kanoop/gui/widgets/moc_widgetplugincollection.cpp"


### PR DESCRIPTION
## SC-5673 — Include moc files in source files

Part of a coordinated change across all of meta-qt-mains. Each `.cpp` whose header declares `Q_OBJECT`/`Q_GADGET`/`Q_NAMESPACE` now ends with an `#include` of its generated moc file, so AUTOMOC excludes that moc from the aggregate `mocs_compilation.cpp`. Touching one Q_OBJECT header then recompiles only the TUs that include it instead of every moc in the target.

**This repo:** 48 `.cpp` file(s) converted (moc-include edits generated by `tools/check_moc_includes.py --fix` in meta-qt-mains).

**CMakeLists change (this is a library):** split include/src headers require a path-prefixed moc include, which makes Qt's metatype JSON generation (`moc --collect-json`) fail on a clean build. Nothing in this project consumes that JSON (no QML / qmltyperegistrar), so it is suppressed per target via `MANUAL_FINALIZATION` + `INTERFACE_QT_META_TYPES_BUILD_FILE` + `qt_finalize_target`. No source behavior changes.

**Measured (pulse, 64 cores, ccache disabled):** header-touch incremental rebuild 40s → 17s (−57%); clean build unchanged.

> **Merge coordination:** one of 13 PRs under SC-5673 (12 submodules + meta-qt-mains). The meta PR bumps all submodule pointers and its CI guard only passes once the pointers reference these merged commits. Submodule PRs are independent and can merge in any order; the meta PR goes last.

## Validation Steps

- [ ] Full project builds clean from scratch
  1. From a meta-qt-mains checkout with this branch's commit in the `KanoopGuiQt` submodule, wipe the build dir and configure fresh, then `cmake --build build/Desktop_Qt_6_10_1-Debug --target all --parallel`
  2. Build completes with no errors and no warnings (`-Wall -Wextra -Werror`). In particular the `moc --collect-json` / metatypes step does not fail for `KanoopGuiQt`.

- [ ] Unit tests pass
  1. Run `QT_QPA_PLATFORM=offscreen ctest --test-dir build/Desktop_Qt_6_10_1-Debug --output-on-failure`
  2. Final line reads `100% tests passed`

- [ ] moc-include guard passes
  1. From the meta-qt-mains root run `python3 tools/check_moc_includes.py KanoopGuiQt`
  2. Exits 0 with no output

🤖 Generated with [Claude Code](https://claude.com/claude-code)
