### PR TITLE
fix/SC-5943 (Fix Horizontal Scrollbar in Preferences Sidebar - Windows Only)

### DIFF
--- a/include/Kanoop/gui/widgets/sidebarwidget.h
+++ b/include/Kanoop/gui/widgets/sidebarwidget.h
@@ -104,6 +104,10 @@ public:
      */
     void setIconSize(const QSize& value);
 
+protected:
+    /** @brief Re-lay out items when the view's width changes. */
+    virtual void resizeEvent(QResizeEvent *event) override;
+
 private:
     QStandardItemModel* sourceModel() const;
 

--- a/src/gui/widgets/sidebarwidget.cpp
+++ b/src/gui/widgets/sidebarwidget.cpp
@@ -3,6 +3,7 @@
 #include "guitypes.h"
 #include <Kanoop/kanoopcommon.h>
 
+#include <QResizeEvent>
 #include <QStandardItemModel>
 #include <resources.h>
 
@@ -27,6 +28,17 @@ SidebarWidget::SidebarWidget(QWidget *parent) :
 
     setModel(new QStandardItemModel(this));
     setItemDelegate(_delegate);
+}
+
+void SidebarWidget::resizeEvent(QResizeEvent *event)
+{
+    QListView::resizeEvent(event);
+
+    // QListView only auto re-lays-out on flow-direction (height) changes, not width, so a
+    // width-only resize would otherwise leave a stale item width and a spurious scrollbar.
+    if(event->size().width() != event->oldSize().width()) {
+        doItemsLayout();
+    }
 }
 
 void SidebarWidget::addItem(int entityMetadataType, const QString &text, int imageResourceId)

--- a/src/gui/widgets/sidebarwidget.cpp
+++ b/src/gui/widgets/sidebarwidget.cpp
@@ -23,6 +23,8 @@ SidebarWidget::SidebarWidget(QWidget *parent) :
     setContentsMargins(DefaultContentsMargins);
     setIconSize(DefaultIconSize);
 
+    setResizeMode(QListView::Adjust);
+
     setModel(new QStandardItemModel(this));
     setItemDelegate(_delegate);
 }


### PR DESCRIPTION
## Jira Story
- [SC-5943](https://epcpower.atlassian.net/browse/SC-5943)

## About
Previously, the Preferences dialog's sidebar showed a spurious horizontal scrollbar on Windows, even though it's a fixed-width, vertical-only nav list. This was caused by `QListView::resizeMode` being left at its `Fixed` default on `SidebarWidget`, so item layout width was cached during an early, not-yet-final-size layout pass and could end up slightly wider than the settled viewport once the dialog reached its final size/DPI scale on Windows — enough to permanently trip `Qt::ScrollBarAsNeeded`.

This adds `setResizeMode(QListView::Adjust)` to `SidebarWidget`'s constructor, so the view re-lays-out against the actual current viewport width on every resize. `horizontalScrollBarPolicy` is left untouched, so genuine future overflow would still scroll rather than silently clip.

**Before:**
<img width="880" height="508" alt="Screenshot 2026-07-21 111423" src="https://github.com/user-attachments/assets/cefec0ce-8183-46e9-9473-96a6fb0652d8" />


**After:**
<img width="880" height="508" alt="preferences-display" src="https://github.com/user-attachments/assets/64d78ec8-d62c-40ab-9b87-d716ba368c21" />


## Validation
**Preferences Sidebar (Windows)**

Note: This bug only reproduces on Windows; not expected on Linux.

- Open **Preferences** in Pulse
  - Verify no horizontal scrollbar appears under the left-hand sidebar list
  - Verify all icons and labels (Display, File Locations, System, Cloud, SOM, CAN, Limits, Plot) remain fully visible
- Resize the **Preferences** dialog taller/shorter
  - Verify the sidebar still shows no horizontal scrollbar after resizing