### PR TITLE
story(SC-6071): StandardMenus and delegate ownership tolerance

### DIFF
--- a/include/Kanoop/gui/mainwindowbase.h
+++ b/include/Kanoop/gui/mainwindowbase.h
@@ -18,6 +18,8 @@
 #include <Kanoop/timespan.h>
 #include <Kanoop/gui/widgets/statusbar.h>
 
+class StandardMenus;
+
 class QMdiArea;
 
 /**
@@ -38,6 +40,24 @@ public:
      * @param parent Optional QWidget parent
      */
     explicit MainWindowBase(const QString& loggingCategory, QWidget *parent = nullptr);
+
+    /**
+     * @brief Contributes this window's commands to the shell's menus.
+     *
+     * Called when the window becomes the active sub-window of an MdiWindow. A window
+     * hosted in an MDI area has no menu bar of its own; it inserts its actions into the
+     * shell's menus here and takes them out again in removeWindowMenus(), so the menu
+     * bar always reflects the window being looked at.
+     *
+     * @param menus The shell's standard menus
+     */
+    virtual void addWindowMenus(const StandardMenus& menus) { Q_UNUSED(menus) }
+
+    /**
+     * @brief Withdraws this window's commands from the shell's menus.
+     * @param menus The shell's standard menus
+     */
+    virtual void removeWindowMenus(const StandardMenus& menus) { Q_UNUSED(menus) }
 
     /**
      * @brief Return whether the window persists its position between sessions.

--- a/include/Kanoop/gui/standardmenus.h
+++ b/include/Kanoop/gui/standardmenus.h
@@ -1,0 +1,73 @@
+#ifndef STANDARDMENUS_H
+#define STANDARDMENUS_H
+
+#include <Kanoop/gui/libkanoopgui.h>
+
+#include <QMenu>
+
+/**
+ * @brief The conventional top-level menus of a main window, resolved by title.
+ *
+ * An MDI shell owns one set of these and hands them to whichever sub-window is being
+ * activated, so a sub-window contributes its commands into the shell's menus rather
+ * than carrying a menu bar of its own. Menus are matched on their title text with
+ * accelerators and case ignored, so a shell declaring "&File" resolves as File.
+ */
+class LIBKANOOPGUI_EXPORT StandardMenus
+{
+public:
+    /** @brief The conventional top-level menus. */
+    enum Menu
+    {
+        File,
+        Edit,
+        Window,
+        Help,
+    };
+
+    /** @brief Constructs an empty set. */
+    StandardMenus() {}
+
+    /**
+     * @brief Constructs a set by resolving each menu from its title.
+     * @param menus Top-level menus of the owning window; unrecognized titles are ignored
+     */
+    StandardMenus(const QList<QMenu*>& menus);
+
+    /**
+     * @brief Returns the menu of the given type.
+     * @param menuType Which conventional menu to return
+     * @return The menu, or nullptr when the owning window has no such menu
+     */
+    QMenu* menu(Menu menuType) const { return _menus.value(menuType); }
+
+    /**
+     * @brief Returns the action following a separator, for use as an insertion point.
+     * @param menuType Which conventional menu to search
+     * @param number Zero-based index of the separator to search from
+     * @return The action after that separator, or nullptr
+     */
+    QAction* firstAfterSeperator(Menu menuType, int number = 0) const;
+
+    /**
+     * @brief Returns the action following the one with the given text.
+     * @param menuType Which conventional menu to search
+     * @param text Text of the action to search from, accelerators and case ignored
+     * @param number Zero-based index of the match to search from
+     * @return The action after the match, or nullptr
+     */
+    QAction* firstAfterText(Menu menuType, const QString& text, int number = 0) const;
+
+    /** @brief Returns the action following a separator in an arbitrary menu. */
+    static QAction* firstAfterSeperator(const QMenu* menu, int number = 0);
+
+    /** @brief Returns the action following the one with the given text in an arbitrary menu. */
+    static QAction* firstAfterText(const QMenu* menu, const QString& text, int number = 0);
+
+private:
+    QMap<Menu, QMenu*> _menus;
+
+    static QString simplified(const QString& text);
+};
+
+#endif // STANDARDMENUS_H

--- a/include/Kanoop/gui/tableviewbase.h
+++ b/include/Kanoop/gui/tableviewbase.h
@@ -142,8 +142,14 @@ public:
 
     /**
      * @brief Assign a custom item delegate to the column of the given header type.
+     *
+     * The view takes ownership, reparenting the delegate to itself. One delegate may be
+     * assigned to several columns of the same view, and is destroyed once, with the view.
+     * It may not be shared with another view: a QObject has one parent, so registering it
+     * elsewhere hands ownership over and it dies with whichever view took it last.
+     *
      * @param type Column header type identifier
-     * @param delegate Delegate to install
+     * @param delegate Delegate to install; ownership passes to this view
      */
     void setColumnDelegate(int type, QStyledItemDelegate* delegate);
 

--- a/include/Kanoop/gui/treeviewbase.h
+++ b/include/Kanoop/gui/treeviewbase.h
@@ -206,8 +206,14 @@ public:
 
     /**
      * @brief Assign a custom item delegate to the column of the given header type.
+     *
+     * The view takes ownership, reparenting the delegate to itself. One delegate may be
+     * assigned to several columns of the same view, and is destroyed once, with the view.
+     * It may not be shared with another view: a QObject has one parent, so registering it
+     * elsewhere hands ownership over and it dies with whichever view took it last.
+     *
      * @param type Column header type identifier
-     * @param delegate Delegate to install
+     * @param delegate Delegate to install; ownership passes to this view
      */
     void setColumnDelegate(int type, QStyledItemDelegate* delegate);
 

--- a/src/gui/standardmenus.cpp
+++ b/src/gui/standardmenus.cpp
@@ -1,0 +1,64 @@
+#include <Kanoop/gui/standardmenus.h>
+
+StandardMenus::StandardMenus(const QList<QMenu*>& menus)
+{
+    for(QMenu* menu : menus) {
+        QString text = simplified(menu->title());
+        if(text.toLower() == "file") {
+            _menus.insert(File, menu);
+        }
+        else if(text.toLower() == "edit") {
+            _menus.insert(Edit, menu);
+        }
+        else if(text.toLower() == "help") {
+            _menus.insert(Help, menu);
+        }
+        else if(text.toLower() == "window") {
+            _menus.insert(Window, menu);
+        }
+    }
+}
+
+QAction* StandardMenus::firstAfterSeperator(Menu menuType, int number) const
+{
+    QMenu* menu = _menus.value(menuType);
+    return menu == nullptr ? nullptr : firstAfterSeperator(menu, number);
+}
+
+QAction* StandardMenus::firstAfterText(Menu menuType, const QString& text, int number) const
+{
+    QMenu* menu = _menus.value(menuType);
+    return menu == nullptr ? nullptr : firstAfterText(menu, text, number);
+}
+
+QAction* StandardMenus::firstAfterSeperator(const QMenu* menu, int number)
+{
+    int count = -1;
+    for(int i = 0;i < menu->actions().count();i++) {
+        QAction* action = menu->actions().at(i);
+        if(action->isSeparator() && ++count == number) {
+            return i < menu->actions().count() - 1 ? menu->actions().at(i + 1) : nullptr;
+        }
+    }
+    return nullptr;
+}
+
+QAction* StandardMenus::firstAfterText(const QMenu* menu, const QString& text, int number)
+{
+    int count = -1;
+    for(int i = 0;i < menu->actions().count();i++) {
+        QAction* action = menu->actions().at(i);
+        if(simplified(text) == simplified(action->text()) && ++count == number) {
+            return i < menu->actions().count() - 1 ? menu->actions().at(i + 1) : nullptr;
+        }
+    }
+    return nullptr;
+}
+
+QString StandardMenus::simplified(const QString& text)
+{
+    QString result = text;
+    result.remove('&');
+    result = result.toLower();
+    return result;
+}

--- a/src/gui/tableviewbase.cpp
+++ b/src/gui/tableviewbase.cpp
@@ -79,7 +79,10 @@ TableViewBase::TableViewBase(QWidget *parent) :
 
 TableViewBase::~TableViewBase()
 {
-    qDeleteAll(_columnDelegates);
+    // The delegates are children of this view and die with it. They are deliberately not
+    // deleted here: one delegate is commonly registered against several columns, so the
+    // map holds the same pointer under more than one key and deleting its values would
+    // free it once per column.
 }
 
 void TableViewBase::setModel(QAbstractItemModel *model)
@@ -243,10 +246,22 @@ void TableViewBase::restoreVerticalHeaderState()
 void TableViewBase::setColumnDelegate(int type, QStyledItemDelegate *delegate)
 {
     QStyledItemDelegate* existing = _columnDelegates.value(type);
-    if(existing != nullptr) {
-        _columnDelegates.remove(type);
+    if(existing == delegate) {
+        return;
+    }
+
+    _columnDelegates.remove(type);
+
+    // A delegate is often shared across columns, so the one being replaced is only
+    // finished with when no other column still points at it.
+    if(existing != nullptr && _columnDelegates.values().contains(existing) == false) {
         existing->deleteLater();
     }
+
+    // The view owns its delegates through the object tree, and owns them once.
+    // setItemDelegateForColumn() does not take ownership.
+    delegate->setParent(this);
+
     int column = sourceModel()->columnForHeader(type);
     if(column != -1) {
         _columnDelegates.insert(type, delegate);

--- a/src/gui/treeviewbase.cpp
+++ b/src/gui/treeviewbase.cpp
@@ -369,10 +369,22 @@ bool TreeViewBase::isIndexVisible(const QModelIndex& index) const
 void TreeViewBase::setColumnDelegate(int type, QStyledItemDelegate *delegate)
 {
     QStyledItemDelegate* existing = _columnDelegates.value(type);
-    if(existing != nullptr) {
-        _columnDelegates.remove(type);
-        delete existing;
+    if(existing == delegate) {
+        return;
     }
+
+    _columnDelegates.remove(type);
+
+    // A delegate is often shared across columns, so the one being replaced is only
+    // finished with when no other column still points at it.
+    if(existing != nullptr && _columnDelegates.values().contains(existing) == false) {
+        existing->deleteLater();
+    }
+
+    // The view owns its delegates through the object tree, and owns them once.
+    // setItemDelegateForColumn() does not take ownership.
+    delegate->setParent(this);
+
     int column = sourceModel()->columnForHeader(type);
     if(column != -1) {
         _columnDelegates.insert(type, delegate);


### PR DESCRIPTION
Two library additions driven by the m-simulator MDI work (EPC Oracle POC):

- **StandardMenus + menu contribution hooks** — an MDI shell owns its menus; hosted child windows contribute entries instead of adopting the bar, so shell-level defaults persist when the active child contributes nothing.
- **Delegate ownership tolerance in TableViewBase/TreeViewBase** — setColumnDelegate now reparents the delegate to the view and a replaced delegate is deleted only when no other column references it. Per-view sharing across columns is supported; sharing one delegate across views is not (single QObject parent). Pure added tolerance: the existing one-delegate-per-column convention is unaffected.

## Validation Steps

- [ ] Delegate teardown
  1. In a client app, register one delegate under several columns of one view (m-simulator's SimAnomalyTableView does this), open and close the hosting window → no double-delete crash
- [ ] Menu contribution
  1. In an MDI client (m-simulator story/SC-6071), switch between child windows → shell menus keep their default entries; child-specific entries appear and disappear with the child

🤖 Generated with [Claude Code](https://claude.com/claude-code)