### PR TITLE
fix(SC-5312): give dialogs the application icon rather than their parent's

### DIFF
--- a/src/gui/dialog.cpp
+++ b/src/gui/dialog.cpp
@@ -17,6 +17,7 @@
 #include <QShowEvent>
 #include <QTimer>
 
+#include <QApplication>
 #include <QCheckBox>
 #include <QComboBox>
 #include <QLineEdit>
@@ -61,6 +62,18 @@ Dialog::~Dialog()
 void Dialog::commonInit()
 {
     Dialog::setObjectName(Dialog::metaObject()->className());
+
+    // QWidget::windowIcon() walks up the parent chain and returns the first ancestor that has an
+    // icon, reaching the application icon only when nobody above has one. A dialog parented to a
+    // window with its own icon therefore inherits that window's icon rather than the application's.
+    //
+    // Guarded against a null application icon: setWindowIcon() stores whatever it is given, and
+    // the getter tests the stored pointer rather than WA_SetWindowIcon, so setting a null icon
+    // would permanently suppress the inheritance for an application that sets none of its own.
+    const QIcon applicationIcon = QApplication::windowIcon();
+    if(applicationIcon.isNull() == false) {
+        Dialog::setWindowIcon(applicationIcon);
+    }
 
     _buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel | QDialogButtonBox::Apply);
     connectButtonBoxSignals();


### PR DESCRIPTION
## What

One guarded line in `Dialog::commonInit()` so dialogs show the application icon instead of inheriting whatever icon their parent window happens to have.

```cpp
const QIcon applicationIcon = QApplication::windowIcon();
if(applicationIcon.isNull() == false) {
    Dialog::setWindowIcon(applicationIcon);
}
```

## Why — the part that isn't obvious from the diff

`QWidget::windowIcon()` walks up the **parent chain** and returns the first ancestor that has an icon, reaching the application icon only when nothing above has one:

```cpp
QIcon QWidget::windowIcon() const
{
    const QWidget *w = this;
    while (w) {
        if (d->extra && d->extra->topextra && d->extra->topextra->icon)
            return *d->extra->topextra->icon;   // nearest ancestor wins
        w = w->parentWidget();
    }
    return QApplication::windowIcon();          // only if nobody above has one
}
```

So a dialog parented to a window that sets its own icon inherits that icon. In Pulse this was visible: `InverterControlWindow` uses a red LED as its window icon to indicate connection state, so every dialog opened from it appeared with a red LED rather than the Pulse icon.

Setting the icon on the dialog itself terminates the walk there.

## Why the null guard

`setWindowIcon()` stores whatever it is given, including a null icon, and the getter tests the stored pointer rather than `WA_SetWindowIcon`:

```cpp
setAttribute(Qt::WA_SetWindowIcon, !icon.isNull());
d->extra->topextra->icon = std::make_unique<QIcon>(icon);   // stored even when null
```

So an unguarded call would permanently suppress the inheritance for any application that sets no application-level icon. Several consumers of this library — m-simulator, pm-plus, SimpleModbus — set icons only on their main windows, and the guard leaves their behaviour unchanged.

## Validation Steps

- [ ] Dialogs opened from a window with its own icon show the application icon
  1. Build Pulse against this branch and launch it
  2. Open an Inverter Control window — note its title-bar icon is a red LED
  3. From that window open Query Options (or any dialog)
  4. Confirm the dialog's title-bar icon is the Pulse icon, not the red LED

- [ ] Applications without an application-level icon are unaffected
  1. Launch m-simulator built against this branch
  2. Open any dialog from its main window
  3. Confirm the dialog's icon behaviour is unchanged from `master`

- [ ] Dialogs that set their own icon still win
  1. If any dialog in your tree calls `setWindowIcon()` in its own constructor, open it
  2. Confirm it still shows its own icon — `commonInit()` runs before the subclass constructor, so a subclass override takes precedence

🤖 Generated with [Claude Code](https://claude.com/claude-code)